### PR TITLE
Add Discord chat exporter extension

### DIFF
--- a/examples/discord_export_extension/README.md
+++ b/examples/discord_export_extension/README.md
@@ -1,0 +1,18 @@
+# Discord Chat Exporter Extension
+
+This directory contains a minimal Chrome extension that exports the currently open Discord chat as an HTML file. It uses your logged-in session so you don't need to manually enter any credentials.
+
+## Files
+- `manifest.json` – extension manifest declaring permissions and scripts.
+- `content.js` – injected into Discord pages to obtain the auth token and add an **Export Chat** button.
+- `background.js` – service worker that fetches messages and saves them as an HTML file.
+
+## Loading the Extension in Chrome
+1. Download or clone this repository so you have these files on your computer.
+2. Open Chrome and go to `chrome://extensions/`.
+3. Enable **Developer mode** (toggle in the top right).
+4. Click **Load unpacked** and select this `discord_export_extension` folder.
+5. Open Discord in a new tab, navigate to the chat you want to save, then click the **Export Chat** button that appears in the toolbar.
+6. The extension will download an HTML file with your chat history in reverse order (newest messages first).
+
+No other setup is required.

--- a/examples/discord_export_extension/background.js
+++ b/examples/discord_export_extension/background.js
@@ -1,0 +1,65 @@
+// Store Discord auth token received from content script
+let authToken = null;
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'token') {
+    authToken = msg.token;
+  } else if (msg.type === 'export') {
+    if (!authToken) {
+      console.error('No token available');
+      return;
+    }
+    exportChannel(msg.channelId);
+  }
+});
+
+async function exportChannel(channelId) {
+  const fileName = `discord-${channelId}.html`;
+  // Accumulate HTML chunks in memory and download when complete
+  const chunks = [];
+
+  const header = `<!doctype html><meta charset="utf-8"><body>`;
+  const footer = `</body>`;
+  chunks.push(header);
+
+  let before = null;
+  while (true) {
+    const url = `https://discord.com/api/v9/channels/${channelId}/messages?limit=100` + (before ? `&before=${before}` : '');
+    const res = await fetch(url, { headers: { authorization: authToken } });
+    if (res.status === 429) {
+      const data = await res.json();
+      await delay((data.retry_after || 1) * 1000);
+      continue;
+    }
+    const messages = await res.json();
+    if (!messages.length) break;
+    before = messages[messages.length - 1].id;
+    const html = messages.map(renderMessage).join('\n');
+    chunks.push(html);
+    await delay(100); // gentle pacing
+  }
+
+  chunks.push(footer);
+  const blob = new Blob(chunks, { type: 'text/html' });
+  const url = URL.createObjectURL(blob);
+  chrome.downloads.download({ url, filename: fileName, saveAs: true });
+}
+
+function renderMessage(m) {
+  const time = new Date(m.timestamp).toLocaleString();
+  const content = escapeHtml(m.content || '');
+  return `<div><span>[${time}]</span> <b>${escapeHtml(m.author.username)}</b>: ${content}</div>`;
+}
+
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function delay(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}

--- a/examples/discord_export_extension/content.js
+++ b/examples/discord_export_extension/content.js
@@ -1,0 +1,33 @@
+// Grab token from Discord's localStorage and send to background
+(function() {
+  const tokenRaw = window.localStorage.getItem('token');
+  if (tokenRaw) {
+    try {
+      const token = JSON.parse(tokenRaw);
+      chrome.runtime.sendMessage({ type: 'token', token });
+    } catch (e) {
+      console.error('Token parse failed');
+    }
+  }
+
+  // Add a simple button into the UI for demonstration
+  function addExportButton() {
+    if (document.getElementById('dcc-export-btn')) return;
+    const toolbar = document.querySelector('[class*="toolbar-"], header');
+    if (!toolbar) return;
+    const btn = document.createElement('button');
+    btn.id = 'dcc-export-btn';
+    btn.textContent = 'Export Chat';
+    btn.style.marginLeft = '8px';
+    btn.onclick = () => {
+      const parts = location.pathname.split('/');
+      const channelId = parts[parts.length - 1];
+      chrome.runtime.sendMessage({ type: 'export', channelId });
+    };
+    toolbar.appendChild(btn);
+  }
+
+  const observer = new MutationObserver(addExportButton);
+  observer.observe(document.body, { childList: true, subtree: true });
+  addExportButton();
+})();

--- a/examples/discord_export_extension/manifest.json
+++ b/examples/discord_export_extension/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "Discord Chat Exporter",
+  "description": "Export current Discord chat history in reverse order.",
+  "version": "0.1",
+  "permissions": ["downloads"],
+  "host_permissions": ["https://discord.com/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://discord.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "action": {
+    "default_title": "Export Discord Chat"
+  }
+}


### PR DESCRIPTION
## Summary
- add example Chrome extension to export Discord chat history
- update manifest and background script for easier Chrome import
- add README with loading instructions

## Testing
- `node --check examples/discord_export_extension/background.js`
- `node --check examples/discord_export_extension/content.js`


------
https://chatgpt.com/codex/tasks/task_e_6874b33b9bb88326bdea493e1722b767